### PR TITLE
修复企业微信端使用onMenuShareWechat方法不能正常使用BUG

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@
     var h = {
       config: "preVerifyJSAPI",
       onMenuShareTimeline: "menu:share:timeline",
+      onMenuShareWechat: "menu:share:wechat",
       onMenuShareAppMessage: "menu:share:appmessage",
       onMenuShareQQ: "menu:share:qq",
       onMenuShareWeibo: "menu:share:weiboApp",
@@ -286,6 +287,22 @@
         t(h.onMenuShareTimeline, {
           complete: function() {
             i("shareTimeline", {
+              title: e.title || I,
+              desc: e.title || I,
+              img_url: e.imgUrl || "",
+              link: e.link || location.href,
+              type: e.type || "link",
+              data_url: e.dataUrl || ""
+            },
+            e)
+          }
+        },
+        e)
+      },
+      onMenuShareWechat: function(e) {
+        t(h.onMenuShareWechat, {
+          complete: function() {
+            i("shareWechat", {
               title: e.title || I,
               desc: e.title || I,
               img_url: e.imgUrl || "",


### PR DESCRIPTION
虽然企业微信官方文档有该方法，但是代码中却没有相关代码段，开发项目刚好遇到，故增加该功能代码段，本人已测试通过